### PR TITLE
fix to work with the latest version of delve

### DIFF
--- a/go-dlv.el
+++ b/go-dlv.el
@@ -38,10 +38,10 @@
 
 (require 'gud)
 
-;; Last group is for return value, e.g. "> test.py(2)foo()->None"
-;; Either file or function name may be omitted: "> <string>(0)?()"
+;; Sample marker line:
+;; > main.main() ./test.go:10 (hits goroutine(5):1 total:1)
 (defvar go-dlv-marker-regexp
-  "^> .+(.*) \\(.+\\)\\:\\([0-9]+\\)$")
+  "^> .+(.*) \\(.+\\)\\:\\([0-9]+\\)")
 (defvar go-dlv-marker-regexp-file-group 1)
 (defvar go-dlv-marker-regexp-line-group 2)
 


### PR DESCRIPTION
The format of breakpoint output changed recently in delve. Update marker regex
to work with both new and old formats. Also remove non-relevant comments.

For more details check the following delve commit:
https://github.com/derekparker/delve/commit/197c1656991debbe12726271956ba6c89d8671af
