### PR TITLE
fix marker-regexp

### DIFF
--- a/go-dlv.el
+++ b/go-dlv.el
@@ -43,7 +43,7 @@
 ;; Sample marker line:
 ;; > main.main() ./test.go:10 (hits goroutine(5):1 total:1)
 (defvar go-dlv-marker-regexp
-  "^> .+(.*) \\(.+\\)\\:\\([0-9]+\\) (hits.+)$")
+  "^> .+(.*) \\(.+\\)\\:\\([0-9]+\\).*?$")
 (defvar go-dlv-marker-regexp-file-group 1)
 (defvar go-dlv-marker-regexp-line-group 2)
 


### PR DESCRIPTION
next and step were broken since they hits is not rendered:

```
> main.(*daemon).run() ./main.go:151 (hits goroutine(6):1 total:1)
   150:         
=> 151:     foo
    152: 
(dlv) n
> main.(*daemon).run() ./main.go:158
   157: 
=> 158:     bar
   159:     
```
