### PR TITLE
adapt obsolete macro to emacs 28, and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data

--- a/go-dlv.el
+++ b/go-dlv.el
@@ -107,8 +107,7 @@
 
     output))
 
-(define-obsolete-variable-alias 'go-dlv-command-name
-  'gud-dlv-command-name)
+(define-obsolete-variable-alias 'go-dlv-command-name 'gud-dlv-command-name "0.4.0")
 
 (defcustom gud-dlv-command-name "dlv"
   "File name for executing the Go Delve debugger.


### PR DESCRIPTION
```define-obsolete-variable-alias``` gets called with too few args on emacs 28. 

Also project needed a gitignore :-)

I know another already created a PR for this